### PR TITLE
Remove implicit imports

### DIFF
--- a/samples/code/my-kotlin-library/build.gradle.kts
+++ b/samples/code/my-kotlin-library/build.gradle.kts
@@ -1,8 +1,5 @@
 
-import org.gradle.api.plugins.JavaBasePlugin
-import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.jvm.tasks.Jar
-import org.gradle.kotlin.dsl.*
 import org.jetbrains.dokka.gradle.DokkaTask
 
 // Use of buildscript {} necessary due to https://github.com/Kotlin/dokka/issues/146

--- a/samples/code/step-2/build.gradle.kts
+++ b/samples/code/step-2/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.gradle.kotlin.dsl.*
-
 plugins {
     `build-scan`
     kotlin("jvm", "1.1.4-3")

--- a/samples/code/step-3/build.gradle.kts
+++ b/samples/code/step-3/build.gradle.kts
@@ -1,5 +1,4 @@
 // tag::dokka-imports[]
-import org.gradle.api.plugins.JavaBasePlugin
 import org.gradle.jvm.tasks.Jar
 // end::dokka-imports[]
 


### PR DESCRIPTION
`org.gradle.jvm.tasks.Jar` still needs to be imported in order to disambiguate `Jar`

See https://github.com/gradle/kotlin-dsl/issues/483 that fixes this and will be available in the next Kotlin DSL version.